### PR TITLE
BUGFIX: `NoneType` object has no attribute `lstrip`

### DIFF
--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -4,7 +4,7 @@ import urllib.parse
 from dataclasses import dataclass, field
 from io import BufferedReader, FileIO
 from pathlib import Path
-from typing import Any, Optional, Union, cast
+from typing import Any, Optional, Union
 
 from httpx import HTTPError, Response
 
@@ -167,9 +167,10 @@ class SyncBucketActionsMixin:
             json=json,
         )
         data = response.json()
-        data[
-            "signedURL"
-        ] = f"{self._client.base_url}{cast(str, data['signedURL']).lstrip('/')}"
+        if data['signedURL']:
+            data[
+                "signedURL"
+            ] = f"{self._client.base_url}{str, data['signedURL'].lstrip('/')}"
         return data
 
     def create_signed_urls(
@@ -196,9 +197,10 @@ class SyncBucketActionsMixin:
         )
         data = response.json()
         for item in data:
-            item[
-                "signedURL"
-            ] = f"{self._client.base_url}{cast(str, item['signedURL']).lstrip('/')}"
+            if item['signedURL']:
+                item[
+                    "signedURL"
+                ] = f"{self._client.base_url}{str, item['signedURL'].lstrip('/')}"
         return data
 
     def get_public_url(self, path: str, options: TransformOptions = {}) -> str:


### PR DESCRIPTION
Checking if "signedURL" exists before trying to strip "/". `cast` doesn't convert `NoneType` to `str` at runtime if there is no signedURL returned.

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
If `get_signed_url` or `get_signed_urls` don't return a signedURL for a file, `cast(str, item['signedURL']).lstrip('/')` fails with error 'NoneType' object has no attribute 'lstrip'.

## What is the new behavior?
`item['signedURL'].lstrip('/')` will run only if `item['signedURL']` exists.
Also removed `cast` from import as it was only being used here.

## Additional context

Add any other context or screenshots.
