### PR TITLE
feat: Buckets no longer have methods on them

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -451,10 +451,8 @@ class AsyncBucketActionsMixin:
 # adding this mixin on the BaseBucket means that those bucket objects can also be used to
 # run methods like `upload` and `download`
 @dataclass(repr=False)
-class AsyncBucket(BaseBucket, AsyncBucketActionsMixin):
+class AsyncBucket(BaseBucket):
     """Represents a storage bucket."""
-
-    _client: AsyncClient = field(repr=False)
 
 
 @dataclass

--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -447,9 +447,6 @@ class AsyncBucketActionsMixin:
         return f"{self.id}/{path}"
 
 
-# this class is returned by methods that fetch buckets, for example StorageBucketAPI.get_bucket
-# adding this mixin on the BaseBucket means that those bucket objects can also be used to
-# run methods like `upload` and `download`
 @dataclass(repr=False)
 class AsyncBucket(BaseBucket):
     """Represents a storage bucket."""

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -445,9 +445,6 @@ class SyncBucketActionsMixin:
         return f"{self.id}/{path}"
 
 
-# this class is returned by methods that fetch buckets, for example StorageBucketAPI.get_bucket
-# adding this mixin on the BaseBucket means that those bucket objects can also be used to
-# run methods like `upload` and `download`
 @dataclass(repr=False)
 class SyncBucket(BaseBucket):
     """Represents a storage bucket."""

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -449,10 +449,8 @@ class SyncBucketActionsMixin:
 # adding this mixin on the BaseBucket means that those bucket objects can also be used to
 # run methods like `upload` and `download`
 @dataclass(repr=False)
-class SyncBucket(BaseBucket, SyncBucketActionsMixin):
+class SyncBucket(BaseBucket):
     """Represents a storage bucket."""
-
-    _client: SyncClient = field(repr=False)
 
 
 @dataclass


### PR DESCRIPTION
## What kind of change does this PR introduce?

It removes the `BucketActionsMixin` from the `Bucket`, there is no documented way of using the library this way which makes this a bug.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
