### PR TITLE
fix: add search params to list buckets method

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -157,7 +157,7 @@ class AsyncBucketActionsMixin:
             options to be passed for downloading or transforming the file.
         """
         json = {"expiresIn": str(expires_in)}
-        download_query = None
+        download_query = ""
         if options.get("download"):
             json.update({"download": options["download"]})
 
@@ -195,7 +195,7 @@ class AsyncBucketActionsMixin:
             options to be passed for downloading the file.
         """
         json = {"paths": paths, "expiresIn": str(expires_in)}
-        download_query = None
+        download_query = ""
         if options.get("download"):
             json.update({"download": options.get("download")})
 
@@ -225,7 +225,7 @@ class AsyncBucketActionsMixin:
             file path, including the path and file name. For example `folder/image.png`.
         """
         _query_string = []
-        download_query = None
+        download_query = ""
         if options.get("download"):
             download_query = (
                 "&download="

--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -157,8 +157,15 @@ class AsyncBucketActionsMixin:
             options to be passed for downloading or transforming the file.
         """
         json = {"expiresIn": str(expires_in)}
+        download_query = None
         if options.get("download"):
             json.update({"download": options["download"]})
+
+            download_query = (
+                "&download="
+                if options.get("download") is True
+                else f"&download={options.get('download')}"
+            )
         if options.get("transform"):
             json.update({"transform": options["transform"]})
 
@@ -170,7 +177,7 @@ class AsyncBucketActionsMixin:
         )
         data = response.json()
         data["signedURL"] = (
-            f"{self._client.base_url}{cast(str, data['signedURL']).lstrip('/')}"
+            f"{self._client.base_url}{cast(str, data['signedURL']).lstrip('/')}{download_query}"
         )
         return data
 
@@ -188,8 +195,15 @@ class AsyncBucketActionsMixin:
             options to be passed for downloading the file.
         """
         json = {"paths": paths, "expiresIn": str(expires_in)}
+        download_query = None
         if options.get("download"):
             json.update({"download": options.get("download")})
+
+            download_query = (
+                "&download="
+                if options.get("download") is True
+                else f"&download={options.get('download')}"
+            )
 
         response = await self._request(
             "POST",
@@ -199,7 +213,7 @@ class AsyncBucketActionsMixin:
         data = response.json()
         for item in data:
             item["signedURL"] = (
-                f"{self._client.base_url}{cast(str, item['signedURL']).lstrip('/')}"
+                f"{self._client.base_url}{cast(str, item['signedURL']).lstrip('/')}{download_query}"
             )
         return data
 
@@ -214,9 +228,9 @@ class AsyncBucketActionsMixin:
         download_query = None
         if options.get("download"):
             download_query = (
-                "download="
+                "&download="
                 if options.get("download") is True
-                else f"download={options.get('download')}"
+                else f"&download={options.get('download')}"
             )
 
         if download_query:
@@ -310,7 +324,7 @@ class AsyncBucketActionsMixin:
         path
             The folder path.
         options
-            Search options, including `limit`, `offset`, and `sortBy`.
+            Search options, including `limit`, `offset`, `sortBy` and `search`.
         """
         extra_options = options or {}
         extra_headers = {"Content-Type": "application/json"}

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -155,8 +155,15 @@ class SyncBucketActionsMixin:
             options to be passed for downloading or transforming the file.
         """
         json = {"expiresIn": str(expires_in)}
+        download_query = None
         if options.get("download"):
             json.update({"download": options["download"]})
+
+            download_query = (
+                "download="
+                if options.get("download") is True
+                else f"download={options.get('download')}"
+            )
         if options.get("transform"):
             json.update({"transform": options["transform"]})
 
@@ -168,7 +175,7 @@ class SyncBucketActionsMixin:
         )
         data = response.json()
         data["signedURL"] = (
-            f"{self._client.base_url}{cast(str, data['signedURL']).lstrip('/')}"
+            f"{self._client.base_url}{cast(str, data['signedURL']).lstrip('/')}{download_query}"
         )
         return data
 
@@ -186,8 +193,15 @@ class SyncBucketActionsMixin:
             options to be passed for downloading the file.
         """
         json = {"paths": paths, "expiresIn": str(expires_in)}
+        download_query = None
         if options.get("download"):
             json.update({"download": options.get("download")})
+
+            download_query = (
+                "download="
+                if options.get("download") is True
+                else f"download={options.get('download')}"
+            )
 
         response = self._request(
             "POST",
@@ -197,7 +211,7 @@ class SyncBucketActionsMixin:
         data = response.json()
         for item in data:
             item["signedURL"] = (
-                f"{self._client.base_url}{cast(str, item['signedURL']).lstrip('/')}"
+                f"{self._client.base_url}{cast(str, item['signedURL']).lstrip('/')}{download_query}"
             )
         return data
 
@@ -308,7 +322,7 @@ class SyncBucketActionsMixin:
         path
             The folder path.
         options
-            Search options, including `limit`, `offset`, and `sortBy`.
+            Search options, including `limit`, `offset`, `sortBy` and `search`.
         """
         extra_options = options or {}
         extra_headers = {"Content-Type": "application/json"}

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -155,14 +155,14 @@ class SyncBucketActionsMixin:
             options to be passed for downloading or transforming the file.
         """
         json = {"expiresIn": str(expires_in)}
-        download_query = None
+        download_query = ""
         if options.get("download"):
             json.update({"download": options["download"]})
 
             download_query = (
-                "download="
+                "&download="
                 if options.get("download") is True
-                else f"download={options.get('download')}"
+                else f"&download={options.get('download')}"
             )
         if options.get("transform"):
             json.update({"transform": options["transform"]})
@@ -193,14 +193,14 @@ class SyncBucketActionsMixin:
             options to be passed for downloading the file.
         """
         json = {"paths": paths, "expiresIn": str(expires_in)}
-        download_query = None
+        download_query = ""
         if options.get("download"):
             json.update({"download": options.get("download")})
 
             download_query = (
-                "download="
+                "&download="
                 if options.get("download") is True
-                else f"download={options.get('download')}"
+                else f"&download={options.get('download')}"
             )
 
         response = self._request(
@@ -223,12 +223,12 @@ class SyncBucketActionsMixin:
             file path, including the path and file name. For example `folder/image.png`.
         """
         _query_string = []
-        download_query = None
+        download_query = ""
         if options.get("download"):
             download_query = (
-                "download="
+                "&download="
                 if options.get("download") is True
-                else f"download={options.get('download')}"
+                else f"&download={options.get('download')}"
             )
 
         if download_query:

--- a/storage3/types.py
+++ b/storage3/types.py
@@ -30,7 +30,7 @@ class BaseBucket:
 
 
 # used in bucket.list method's option parameter
-class _sortByType(TypedDict):
+class _sortByType(TypedDict, total=False):
     column: str
     order: Literal["asc", "desc"]
 
@@ -47,10 +47,11 @@ class CreateOrUpdateBucketOptions(TypedDict, total=False):
     allowed_mime_types: list[str]
 
 
-class ListBucketFilesOptions(TypedDict):
+class ListBucketFilesOptions(TypedDict, total=False):
     limit: int
     offset: int
     sortBy: _sortByType
+    search: str
 
 
 class TransformOptions(TypedDict, total=False):


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add search param to the list buckets method
- Implement the download param correctly in the `create_signed_url`, `create_signed_urls` and `get_public_url` methods

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
