### PR TITLE
fix: incorrect upload return type

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -489,7 +489,7 @@ class AsyncBucketActionsMixin:
         path: str,
         file: Union[BufferedReader, bytes, FileIO, str, Path],
         file_options: Optional[FileOptions] = None,
-    ) -> Response:
+    ) -> UploadResponse:
         """
         Uploads a file to an existing bucket.
 

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -489,7 +489,7 @@ class SyncBucketActionsMixin:
         path: str,
         file: Union[BufferedReader, bytes, FileIO, str, Path],
         file_options: Optional[FileOptions] = None,
-    ) -> Response:
+    ) -> UploadResponse:
         """
         Uploads a file to an existing bucket.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Returning Response as response type

## What is the new behavior?

Returning UploadResponse as response type

## Additional context

https://github.com/supabase/supabase-py/issues/1016
