### PR TITLE
fix: exists method raises error when no file found

### DIFF
--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -357,11 +357,14 @@ class AsyncBucketActionsMixin:
         path
             The path to the file.
         """
-        response = await self._request(
-            "HEAD",
-            f"/object/info/{self.id}/{path}",
-        )
-        return response.status_code == 200
+        try:
+            response = await self._request(
+                "HEAD",
+                f"/object/{self.id}/{path}",
+            )
+            return response.status_code == 200
+        except json.JSONDecodeError:
+            return False
 
     async def list(
         self,

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -357,11 +357,14 @@ class SyncBucketActionsMixin:
         path
             The path to the file.
         """
-        response = self._request(
-            "HEAD",
-            f"/object/info/{self.id}/{path}",
-        )
-        return response.status_code == 200
+        try:
+            response = self._request(
+                "HEAD",
+                f"/object/{self.id}/{path}",
+            )
+            return response.status_code == 200
+        except json.JSONDecodeError:
+            return False
 
     def list(
         self,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`.exists` method is raising an exception when a file is not found

## What is the new behavior?

`.exists` method is returning false when a file is not found

## Additional context

Add any other context or screenshots.
