### PR TITLE
feat: allow injection of httpx client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           version: latest
 
       - name: Start Supabase local development setup
-        run: supabase start --workdir infra -x studio,gotrue,postgrest,inbucket,realtime,edge-runtime,logflare,vector,pgbouncer,pg_prove
+        run: supabase start --workdir infra -x studio,gotrue,postgrest,mailpit,realtime,edge-runtime,logflare,vector,supavisor
 
       - name: Run Tests
         run: make run_tests

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ build_sync:
 	poetry run unasync storage3 tests
 	sed -i '0,/SyncMock, /{s/SyncMock, //}' tests/_sync/test_bucket.py tests/_sync/test_client.py
 	sed -i 's/SyncMock/Mock/g' tests/_sync/test_bucket.py tests/_sync/test_client.py
-	sed -i 's/SyncClient/Client/g' storage3/_sync/client.py storage3/_sync/bucket.py storage3/_sync/file_api.py
+	sed -i 's/SyncClient/Client/g' storage3/_sync/client.py storage3/_sync/bucket.py storage3/_sync/file_api.py tests/_sync/test_bucket.py tests/_sync/test_client.py
 	sed -i 's/self\.session\.aclose/self\.session\.close/g' storage3/_sync/client.py
 
 sleep:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ tests_pre_commit:
 	poetry run pre-commit run --all-files
 
 run_infra:
-	npx supabase --workdir infra start -x studio,gotrue,postgrest,inbucket,realtime,edge-runtime,logflare,vector,pgbouncer,pg_prove
+	npx supabase --workdir infra start -x studio,gotrue,postgrest,mailpit,realtime,edge-runtime,logflare,vector,supavisor
 
 stop_infra:
 	npx supabase --workdir infra stop
@@ -27,6 +27,8 @@ build_sync:
 	poetry run unasync storage3 tests
 	sed -i '0,/SyncMock, /{s/SyncMock, //}' tests/_sync/test_bucket.py tests/_sync/test_client.py
 	sed -i 's/SyncMock/Mock/g' tests/_sync/test_bucket.py tests/_sync/test_client.py
+	sed -i 's/SyncClient/Client/g' storage3/_sync/client.py storage3/_sync/bucket.py storage3/_sync/file_api.py
+	sed -i 's/self\.session\.aclose/self\.session\.close/g' storage3/_sync/client.py
 
 sleep:
 	sleep 2

--- a/README.md
+++ b/README.md
@@ -10,21 +10,22 @@ As it takes some effort to get the headers. We suggest that you use the storage 
 
 
 ```python3
-from storage3 import create_client
+from storage3 import AsyncStorageClient
 
 url = "https://<your_supabase_id>.supabase.co/storage/v1"
 key = "<your api key>"
 headers = {"apiKey": key, "Authorization": f"Bearer {key}"}
 
-# pass in is_async=True to create an async client
-storage_client = create_client(url, headers, is_async=False)
+storage_client = AsyncStorageClient(url, headers)
 
-storage_client.list_buckets()
+async def get_buckets():
+  await storage_client.list_buckets()
 ```
 
 ### Uploading files
 When uploading files, make sure to set the correct mimetype by using the `file_options` argument:
 ```py
-storage_client.from_("bucket").upload("/folder/file.png", file_object, {"content-type": "image/png"})
+async def file_upload():
+  await storage_client.from_("bucket").upload("/folder/file.png", file_object, {"content-type": "image/png"})
 ```
 If no mime type is given, the default `text/plain` will be used.

--- a/poetry.lock
+++ b/poetry.lock
@@ -355,7 +355,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -477,6 +477,21 @@ more-itertools = "*"
 [package.extras]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 test = ["cssselect", "importlib-resources ; python_version < \"3.9\"", "jaraco.test (>=5.1)", "lxml ; python_version < \"3.11\"", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+
+[[package]]
+name = "deprecation"
+version = "2.1.0"
+description = "A library to handle automated deprecations"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
+    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
+]
+
+[package.dependencies]
+packaging = "*"
 
 [[package]]
 name = "dict2css"
@@ -1020,7 +1035,7 @@ version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
     {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
@@ -1862,4 +1877,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "448754fa8c6bca5618230ebef31953afc42db8ae5e94b3b436b7a16fa47385c4"
+content-hash = "7dc61b99b599b570ad19852f8956b89b11a15eb1ef6b386846a9eddc5a15e780"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ version = "0.11.3" # {x-release-please-version}
 httpx = {version = ">=0.26,<0.29", extras = ["http2"]}
 python = "^3.9"
 python-dateutil = "^2.8.2"
+deprecation = "^2.1.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "^25.1.0"
 isort = "^6.0.1"
 pre-commit = "^4.2.0"
@@ -38,8 +39,6 @@ Sphinx = "^7.1.2"
 sphinx-press-theme = "^0.9.1"
 unasync-cli = "^0.0.9"
 coveralls = "^1.8.0"
-
-[tool.poetry.group.dev.dependencies]
 sphinx-toolbox = "^3.4.0"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ sphinx-toolbox = "^3.4.0"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 addopts = "tests"
+filterwarnings = [
+    "ignore::DeprecationWarning", # ignore deprecation warnings globally
+]
 
 [build-system]
 build-backend = "poetry.core.masonry.api"

--- a/storage3/_async/bucket.py
+++ b/storage3/_async/bucket.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from httpx import HTTPStatusError, Response
+from httpx import AsyncClient, HTTPStatusError, Response
 
 from ..exceptions import StorageApiError
 from ..types import CreateOrUpdateBucketOptions, RequestMethod
-from ..utils import AsyncClient
 from .file_api import AsyncBucket
 
 __all__ = ["AsyncStorageBucketAPI"]

--- a/storage3/_async/client.py
+++ b/storage3/_async/client.py
@@ -46,7 +46,7 @@ class AsyncStorageClient(AsyncStorageBucketAPI):
     ) -> AsyncClient:
         if http_client is not None:
             http_client.base_url = base_url
-            http_client.headers = headers
+            http_client.headers.update({**headers})
             return http_client
 
         return AsyncClient(

--- a/storage3/_async/client.py
+++ b/storage3/_async/client.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import Optional
 from warnings import warn
 
+from httpx import AsyncClient
+
 from storage3.constants import DEFAULT_TIMEOUT
 
-from ..utils import AsyncClient
 from ..version import __version__
 from .bucket import AsyncStorageBucketAPI
 from .file_api import AsyncBucketProxy

--- a/storage3/_async/client.py
+++ b/storage3/_async/client.py
@@ -24,12 +24,15 @@ class AsyncStorageClient(AsyncStorageBucketAPI):
         timeout: int = DEFAULT_TIMEOUT,
         verify: bool = True,
         proxy: Optional[str] = None,
+        http_client: Optional[AsyncClient] = None,
     ) -> None:
         headers = {
             "User-Agent": f"supabase-py/storage3 v{__version__}",
             **headers,
         }
-        self.session = self._create_session(url, headers, timeout, verify, proxy)
+        self.session = self._create_session(
+            url, headers, timeout, verify, proxy, http_client
+        )
         super().__init__(self.session)
 
     def _create_session(
@@ -39,7 +42,13 @@ class AsyncStorageClient(AsyncStorageBucketAPI):
         timeout: int,
         verify: bool = True,
         proxy: Optional[str] = None,
+        http_client: Optional[AsyncClient] = None,
     ) -> AsyncClient:
+        if http_client is not None:
+            http_client.base_url = base_url
+            http_client.headers = headers
+            return http_client
+
         return AsyncClient(
             base_url=base_url,
             headers=headers,

--- a/storage3/_async/client.py
+++ b/storage3/_async/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional
+from warnings import warn
 
 from storage3.constants import DEFAULT_TIMEOUT
 
@@ -21,8 +22,8 @@ class AsyncStorageClient(AsyncStorageBucketAPI):
         self,
         url: str,
         headers: dict[str, str],
-        timeout: int = DEFAULT_TIMEOUT,
-        verify: bool = True,
+        timeout: Optional[int] = None,
+        verify: Optional[bool] = None,
         proxy: Optional[str] = None,
         http_client: Optional[AsyncClient] = None,
     ) -> None:
@@ -30,8 +31,36 @@ class AsyncStorageClient(AsyncStorageBucketAPI):
             "User-Agent": f"supabase-py/storage3 v{__version__}",
             **headers,
         }
+
+        if timeout is not None:
+            warn(
+                "The 'timeout' parameter is deprecated. Please configure it in the http client instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if verify is not None:
+            warn(
+                "The 'verify' parameter is deprecated. Please configure it in the http client instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if proxy is not None:
+            warn(
+                "The 'proxy' parameter is deprecated. Please configure it in the http client instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        self.verify = bool(verify) if verify is not None else True
+        self.timeout = int(abs(timeout)) if timeout is not None else DEFAULT_TIMEOUT
+
         self.session = self._create_session(
-            url, headers, timeout, verify, proxy, http_client
+            base_url=url,
+            headers=headers,
+            timeout=self.timeout,
+            verify=self.verify,
+            proxy=proxy,
+            http_client=http_client,
         )
         super().__init__(self.session)
 
@@ -54,7 +83,7 @@ class AsyncStorageClient(AsyncStorageBucketAPI):
             headers=headers,
             timeout=timeout,
             proxy=proxy,
-            verify=bool(verify),
+            verify=verify,
             follow_redirects=True,
             http2=True,
         )

--- a/storage3/_async/client.py
+++ b/storage3/_async/client.py
@@ -92,9 +92,6 @@ class AsyncStorageClient(AsyncStorageBucketAPI):
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        await self.aclose()
-
-    async def aclose(self) -> None:
         await self.session.aclose()
 
     def from_(self, id: str) -> AsyncBucketProxy:

--- a/storage3/_async/file_api.py
+++ b/storage3/_async/file_api.py
@@ -8,7 +8,7 @@ from io import BufferedReader, FileIO
 from pathlib import Path
 from typing import Any, Literal, Optional, Union, cast
 
-from httpx import HTTPStatusError, Response
+from httpx import AsyncClient, HTTPStatusError, Response
 
 from ..constants import DEFAULT_FILE_OPTIONS, DEFAULT_SEARCH_OPTIONS
 from ..exceptions import StorageApiError
@@ -26,7 +26,7 @@ from ..types import (
     UploadResponse,
     URLOptions,
 )
-from ..utils import AsyncClient, StorageException
+from ..utils import StorageException
 
 __all__ = ["AsyncBucket"]
 

--- a/storage3/_sync/bucket.py
+++ b/storage3/_sync/bucket.py
@@ -6,7 +6,7 @@ from httpx import HTTPStatusError, Response
 
 from ..exceptions import StorageApiError
 from ..types import CreateOrUpdateBucketOptions, RequestMethod
-from ..utils import SyncClient
+from ..utils import Client
 from .file_api import SyncBucket
 
 __all__ = ["SyncStorageBucketAPI"]
@@ -15,7 +15,7 @@ __all__ = ["SyncStorageBucketAPI"]
 class SyncStorageBucketAPI:
     """This class abstracts access to the endpoint to the Get, List, Empty, and Delete operations on a bucket"""
 
-    def __init__(self, session: SyncClient) -> None:
+    def __init__(self, session: Client) -> None:
         self._client = session
 
     def _request(

--- a/storage3/_sync/bucket.py
+++ b/storage3/_sync/bucket.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from httpx import HTTPStatusError, Response
+from httpx import Client, HTTPStatusError, Response
 
 from ..exceptions import StorageApiError
 from ..types import CreateOrUpdateBucketOptions, RequestMethod
-from ..utils import Client
 from .file_api import SyncBucket
 
 __all__ = ["SyncStorageBucketAPI"]

--- a/storage3/_sync/client.py
+++ b/storage3/_sync/client.py
@@ -24,12 +24,15 @@ class SyncStorageClient(SyncStorageBucketAPI):
         timeout: int = DEFAULT_TIMEOUT,
         verify: bool = True,
         proxy: Optional[str] = None,
+        http_client: Optional[SyncClient] = None,
     ) -> None:
         headers = {
             "User-Agent": f"supabase-py/storage3 v{__version__}",
             **headers,
         }
-        self.session = self._create_session(url, headers, timeout, verify, proxy)
+        self.session = self._create_session(
+            url, headers, timeout, verify, proxy, http_client
+        )
         super().__init__(self.session)
 
     def _create_session(
@@ -39,7 +42,13 @@ class SyncStorageClient(SyncStorageBucketAPI):
         timeout: int,
         verify: bool = True,
         proxy: Optional[str] = None,
+        http_client: Optional[SyncClient] = None,
     ) -> SyncClient:
+        if http_client is not None:
+            http_client.base_url = base_url
+            http_client.headers = headers
+            return http_client
+
         return SyncClient(
             base_url=base_url,
             headers=headers,

--- a/storage3/_sync/client.py
+++ b/storage3/_sync/client.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from typing import Optional
 from warnings import warn
 
+from httpx import Client
+
 from storage3.constants import DEFAULT_TIMEOUT
 
-from ..utils import Client
 from ..version import __version__
 from .bucket import SyncStorageBucketAPI
 from .file_api import SyncBucketProxy

--- a/storage3/_sync/client.py
+++ b/storage3/_sync/client.py
@@ -46,7 +46,7 @@ class SyncStorageClient(SyncStorageBucketAPI):
     ) -> SyncClient:
         if http_client is not None:
             http_client.base_url = base_url
-            http_client.headers = headers
+            http_client.headers.update({**headers})
             return http_client
 
         return SyncClient(

--- a/storage3/_sync/client.py
+++ b/storage3/_sync/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Optional
+from warnings import warn
 
 from storage3.constants import DEFAULT_TIMEOUT
 
@@ -21,8 +22,8 @@ class SyncStorageClient(SyncStorageBucketAPI):
         self,
         url: str,
         headers: dict[str, str],
-        timeout: int = DEFAULT_TIMEOUT,
-        verify: bool = True,
+        timeout: Optional[int] = None,
+        verify: Optional[bool] = None,
         proxy: Optional[str] = None,
         http_client: Optional[SyncClient] = None,
     ) -> None:
@@ -30,8 +31,36 @@ class SyncStorageClient(SyncStorageBucketAPI):
             "User-Agent": f"supabase-py/storage3 v{__version__}",
             **headers,
         }
+
+        if timeout is not None:
+            warn(
+                "The 'timeout' parameter is deprecated. Please configure it in the http client instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if verify is not None:
+            warn(
+                "The 'verify' parameter is deprecated. Please configure it in the http client instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if proxy is not None:
+            warn(
+                "The 'proxy' parameter is deprecated. Please configure it in the http client instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        self.verify = bool(verify) if verify is not None else True
+        self.timeout = int(abs(timeout)) if timeout is not None else DEFAULT_TIMEOUT
+
         self.session = self._create_session(
-            url, headers, timeout, verify, proxy, http_client
+            base_url=url,
+            headers=headers,
+            timeout=self.timeout,
+            verify=self.verify,
+            proxy=proxy,
+            http_client=http_client,
         )
         super().__init__(self.session)
 
@@ -54,7 +83,7 @@ class SyncStorageClient(SyncStorageBucketAPI):
             headers=headers,
             timeout=timeout,
             proxy=proxy,
-            verify=bool(verify),
+            verify=verify,
             follow_redirects=True,
             http2=True,
         )

--- a/storage3/_sync/client.py
+++ b/storage3/_sync/client.py
@@ -5,7 +5,7 @@ from warnings import warn
 
 from storage3.constants import DEFAULT_TIMEOUT
 
-from ..utils import SyncClient
+from ..utils import Client
 from ..version import __version__
 from .bucket import SyncStorageBucketAPI
 from .file_api import SyncBucketProxy
@@ -25,7 +25,7 @@ class SyncStorageClient(SyncStorageBucketAPI):
         timeout: Optional[int] = None,
         verify: Optional[bool] = None,
         proxy: Optional[str] = None,
-        http_client: Optional[SyncClient] = None,
+        http_client: Optional[Client] = None,
     ) -> None:
         headers = {
             "User-Agent": f"supabase-py/storage3 v{__version__}",
@@ -71,14 +71,14 @@ class SyncStorageClient(SyncStorageBucketAPI):
         timeout: int,
         verify: bool = True,
         proxy: Optional[str] = None,
-        http_client: Optional[SyncClient] = None,
-    ) -> SyncClient:
+        http_client: Optional[Client] = None,
+    ) -> Client:
         if http_client is not None:
             http_client.base_url = base_url
             http_client.headers.update({**headers})
             return http_client
 
-        return SyncClient(
+        return Client(
             base_url=base_url,
             headers=headers,
             timeout=timeout,
@@ -92,10 +92,7 @@ class SyncStorageClient(SyncStorageBucketAPI):
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
-        self.aclose()
-
-    def aclose(self) -> None:
-        self.session.aclose()
+        self.session.close()
 
     def from_(self, id: str) -> SyncBucketProxy:
         """Run a storage file operation.

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -26,7 +26,7 @@ from ..types import (
     UploadResponse,
     URLOptions,
 )
-from ..utils import StorageException, SyncClient
+from ..utils import Client, StorageException
 
 __all__ = ["SyncBucket"]
 
@@ -35,7 +35,7 @@ class SyncBucketActionsMixin:
     """Functions needed to access the file API."""
 
     id: str
-    _client: SyncClient
+    _client: Client
 
     def _request(
         self,
@@ -556,4 +556,4 @@ class SyncBucketProxy(SyncBucketActionsMixin):
     """A bucket proxy, this contains the minimum required fields to query the File API."""
 
     id: str
-    _client: SyncClient = field(repr=False)
+    _client: Client = field(repr=False)

--- a/storage3/_sync/file_api.py
+++ b/storage3/_sync/file_api.py
@@ -8,7 +8,7 @@ from io import BufferedReader, FileIO
 from pathlib import Path
 from typing import Any, Literal, Optional, Union, cast
 
-from httpx import HTTPStatusError, Response
+from httpx import Client, HTTPStatusError, Response
 
 from ..constants import DEFAULT_FILE_OPTIONS, DEFAULT_SEARCH_OPTIONS
 from ..exceptions import StorageApiError
@@ -26,7 +26,7 @@ from ..types import (
     UploadResponse,
     URLOptions,
 )
-from ..utils import Client, StorageException
+from ..utils import StorageException
 
 __all__ = ["SyncBucket"]
 

--- a/storage3/utils.py
+++ b/storage3/utils.py
@@ -1,8 +1,8 @@
 from httpx import AsyncClient as AsyncClient  # noqa: F401
-from httpx import Client as BaseClient
+from httpx import Client
 
 
-class SyncClient(BaseClient):
+class SyncClient(Client):
     def aclose(self) -> None:
         self.close()
 

--- a/storage3/utils.py
+++ b/storage3/utils.py
@@ -1,8 +1,23 @@
+from deprecation import deprecated
 from httpx import AsyncClient as AsyncClient  # noqa: F401
 from httpx import Client
 
+from .version import __version__
+
 
 class SyncClient(Client):
+    @deprecated(
+        "0.11.3", "1.0.0", __version__, "Use `Client` from the httpx package instead"
+    )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @deprecated(
+        "0.11.3",
+        "1.0.0",
+        __version__,
+        "Use `close` method from `Client` in the httpx package instead",
+    )
     def aclose(self) -> None:
         self.close()
 

--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
 import pytest
+from httpx import AsyncClient as HttpxClient
 from httpx import HTTPStatusError, Response
 
 from storage3 import AsyncStorageClient
@@ -13,7 +14,6 @@ from storage3.exceptions import StorageApiError
 from storage3.utils import StorageException
 
 from .. import AsyncBucketProxy
-from ..utils import AsyncClient as HttpxClient
 from ..utils import AsyncFinalizerFactory
 
 if TYPE_CHECKING:

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
+from httpx import Client as HttpxClient
 from httpx import HTTPStatusError, Response
 
 from storage3 import SyncStorageClient
@@ -13,7 +14,6 @@ from storage3.exceptions import StorageApiError
 from storage3.utils import StorageException
 
 from .. import SyncBucketProxy
-from ..utils import SyncClient as HttpxClient
 from ..utils import SyncFinalizerFactory
 
 if TYPE_CHECKING:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,11 @@
 from typing import Dict
 
 import pytest
+from httpx import AsyncClient
+from httpx import Client as SyncClient
 from httpx import Timeout
 
-from storage3 import AsyncStorageClient, SyncStorageClient, create_client
+from storage3 import AsyncStorageClient, SyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT
 
 
@@ -18,7 +20,7 @@ def valid_headers() -> Dict[str, str]:
 
 
 def test_create_async_client(valid_url, valid_headers):
-    client = create_client(url=valid_url, headers=valid_headers, is_async=True)
+    client = AsyncStorageClient(url=valid_url, headers=valid_headers)
 
     assert isinstance(client, AsyncStorageClient)
     assert all(
@@ -28,7 +30,57 @@ def test_create_async_client(valid_url, valid_headers):
 
 
 def test_create_sync_client(valid_url, valid_headers):
-    client = create_client(url=valid_url, headers=valid_headers, is_async=False)
+    client = SyncStorageClient(url=valid_url, headers=valid_headers)
+
+    assert isinstance(client, SyncStorageClient)
+    assert all(
+        client._client.headers[key] == value for key, value in valid_headers.items()
+    )
+    assert client._client.timeout == Timeout(DEFAULT_TIMEOUT)
+
+
+def test_async_storage_client(valid_url, valid_headers):
+    headers = {"x-user-agent": "my-app/0.0.1"}
+    http_client = AsyncClient(headers=headers)
+    client = AsyncStorageClient(
+        url=valid_url, headers=valid_headers, http_client=http_client
+    )
+
+    assert isinstance(client, AsyncStorageClient)
+    assert all(
+        client._client.headers[key] == value for key, value in valid_headers.items()
+    )
+    assert client._client.headers.get("x-user-agent") == "my-app/0.0.1"
+    assert client._client.timeout == Timeout(5.0)
+
+
+def test_sync_storage_client(valid_url, valid_headers):
+    headers = {"x-user-agent": "my-app/0.0.1"}
+    http_client = SyncClient(headers=headers)
+    client = SyncStorageClient(
+        url=valid_url, headers=valid_headers, http_client=http_client
+    )
+
+    assert isinstance(client, SyncStorageClient)
+    assert all(
+        client._client.headers[key] == value for key, value in valid_headers.items()
+    )
+    assert client._client.headers.get("x-user-agent") == "my-app/0.0.1"
+    assert client._client.timeout == Timeout(5.0)
+
+
+def test_async_storage_client_with_httpx(valid_url, valid_headers):
+    client = AsyncStorageClient(url=valid_url, headers=valid_headers)
+
+    assert isinstance(client, AsyncStorageClient)
+    assert all(
+        client._client.headers[key] == value for key, value in valid_headers.items()
+    )
+    assert client._client.timeout == Timeout(DEFAULT_TIMEOUT)
+
+
+def test_sync_storage_client_with_httpx(valid_url, valid_headers):
+    client = SyncStorageClient(url=valid_url, headers=valid_headers)
 
     assert isinstance(client, SyncStorageClient)
     assert all(
@@ -40,24 +92,12 @@ def test_create_sync_client(valid_url, valid_headers):
 def test_custom_timeout(valid_url, valid_headers):
     custom_timeout = 30
 
-    async_client = create_client(
-        url=valid_url, headers=valid_headers, is_async=True, timeout=custom_timeout
+    async_client = AsyncStorageClient(
+        url=valid_url, headers=valid_headers, timeout=custom_timeout
     )
     assert async_client._client.timeout == Timeout(custom_timeout)
 
-    sync_client = create_client(
-        url=valid_url, headers=valid_headers, is_async=False, timeout=custom_timeout
+    sync_client = SyncStorageClient(
+        url=valid_url, headers=valid_headers, timeout=custom_timeout
     )
     assert sync_client._client.timeout == Timeout(custom_timeout)
-
-
-def test_type_hints():
-    from typing import Union, get_type_hints
-
-    hints = get_type_hints(create_client)
-
-    assert hints["url"] == str
-    assert hints["headers"] == dict[str, str]
-    assert hints["is_async"] == bool
-    assert hints["timeout"] == int
-    assert hints["return"] == Union[AsyncStorageClient, SyncStorageClient]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,7 @@
 from typing import Dict
 
 import pytest
-from httpx import AsyncClient
-from httpx import Client as SyncClient
-from httpx import Timeout
+from httpx import AsyncClient, Client, Timeout
 
 from storage3 import AsyncStorageClient, SyncStorageClient
 from storage3.constants import DEFAULT_TIMEOUT
@@ -56,7 +54,7 @@ def test_async_storage_client(valid_url, valid_headers):
 
 def test_sync_storage_client(valid_url, valid_headers):
     headers = {"x-user-agent": "my-app/0.0.1"}
-    http_client = SyncClient(headers=headers)
+    http_client = Client(headers=headers)
     client = SyncStorageClient(
         url=valid_url, headers=valid_headers, http_client=http_client
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from deprecation import fail_if_not_removed
+
 from storage3.utils import SyncClient
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,11 @@
+from deprecation import fail_if_not_removed
+from storage3.utils import SyncClient
+
+
+@fail_if_not_removed
+def test_sync_client():
+    client = SyncClient()
+    # Verify that aclose method exists and calls close
+    assert hasattr(client, "aclose")
+    assert callable(client.aclose)
+    client.aclose()  # Should not raise any exception

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,6 @@
 import asyncio
 from typing import Any, Callable, Coroutine
 
-from httpx import AsyncClient as AsyncClient  # noqa: F401
-from httpx import Client as BaseClient
-
 
 class AsyncFinalizerFactory:
     def __init__(self, finalizer: Callable[[], Coroutine[Any, Any, None]]):
@@ -17,8 +14,3 @@ class AsyncFinalizerFactory:
 class SyncFinalizerFactory:
     def __init__(self, finalizer: Callable[[], None]):
         self.finalizer = finalizer
-
-
-class SyncClient(BaseClient):
-    def aclose(self) -> None:
-        self.close()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow developers to supply their own httpx client

## What is the current behavior?

Httpx client isn't very configurable and has limited options available for the developer

## What is the new behavior?

Httpx client can now be configured by the developer and be supplied to the storage library

## Additional context

Add any other context or screenshots.
