### PR TITLE
chore(ci): update coveralls config to fix failing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,21 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-${{ join(matrix.*, '-') }}
+          parallel: true
+
+  finish_tests:
+    needs: test
+    name: Upload tests coveralls results
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+          carryforward: "run-ubuntu-latest-3.9,run-ubuntu-latest-3.10,run-ubuntu-latest-3.11,run-ubuntu-latest-3.12,run-ubuntu-latest-3.13"
 
   release-please:
     needs: test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '^.*\.(md|MD)$'
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.5.0
+      rev: v5.0.0
       hooks:
           - id: trailing-whitespace
           - id: check-added-large-files
@@ -10,7 +10,7 @@ repos:
             args: ["--fix=lf"]
 
     - repo: https://github.com/pycqa/isort
-      rev: 5.13.2
+      rev: 6.0.1
       hooks:
           - id: isort
             args:
@@ -36,18 +36,18 @@ repos:
                 ]
 
     - repo: https://github.com/psf/black
-      rev: "24.4.0"
+      rev: "25.1.0"
       hooks:
           - id: black
 
     - repo: https://github.com/asottile/pyupgrade
-      rev: v3.15.1
+      rev: v3.20.0
       hooks:
           - id: pyupgrade
             args: ["--py37-plus", "--keep-runtime-typing"]
 
     - repo: https://github.com/commitizen-tools/commitizen
-      rev: v3.22.0
+      rev: v4.8.3
       hooks:
           - id: commitizen
             stages: [commit-msg]


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI failing due to coveralls build not completing, this PR aims to fix that by waiting until all parallel builds are completed before uploading to coveralls.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
