### PR TITLE
fix: add optional type field to bucket metadata

### DIFF
--- a/storage3/types.py
+++ b/storage3/types.py
@@ -21,6 +21,7 @@ class BaseBucket:
     updated_at: datetime
     file_size_limit: Optional[int]
     allowed_mime_types: Optional[list[str]]
+    type: Optional[str] = None
 
     def __post_init__(self) -> None:
         # created_at and updated_at are returned by the API as ISO timestamps


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for missing `type` field in `BaseBucket`. I didn't dig more than that.

## What is the current behavior?

When listing buckets, raise TypeError:

<img width="1909" height="816" alt="image" src="https://github.com/user-attachments/assets/14baf607-7284-4f11-a88e-4c1fb119b98a" />

## What is the new behavior?

Returns my bucket list as expected:

<img width="1902" height="56" alt="image" src="https://github.com/user-attachments/assets/82d33fb4-4985-43d7-b844-db281bd79f12" />

## Additional context

Found this issue in self-hosted environment when upgrading `supabase/storage-api` from `v1.24.7` to `v1.25.9`
