### PR TITLE
fix: remove extraneous char in test

### DIFF
--- a/tests/_async/test_client.py
+++ b/tests/_async/test_client.py
@@ -386,7 +386,7 @@ async def test_client_create_signed_url(
     response.raise_for_status()
     assert (
         response.headers["content-disposition"]
-        == "attachment; filename=custom_download.svg; filename*=UTF-8''custom_download.svg;"
+        == "attachment; filename=custom_download.svg; filename*=UTF-8''custom_download.svg"
     )
     assert response.content == file.file_content
 
@@ -449,7 +449,7 @@ async def test_client_get_public_url(
     response.raise_for_status()
     assert (
         response.headers["content-disposition"]
-        == "attachment; filename=custom_name.svg; filename*=UTF-8''custom_name.svg;"
+        == "attachment; filename=custom_name.svg; filename*=UTF-8''custom_name.svg"
     )
     assert response.content == file.file_content
 

--- a/tests/_sync/test_client.py
+++ b/tests/_sync/test_client.py
@@ -382,7 +382,7 @@ def test_client_create_signed_url(
     response.raise_for_status()
     assert (
         response.headers["content-disposition"]
-        == "attachment; filename=custom_download.svg; filename*=UTF-8''custom_download.svg;"
+        == "attachment; filename=custom_download.svg; filename*=UTF-8''custom_download.svg"
     )
     assert response.content == file.file_content
 
@@ -445,7 +445,7 @@ def test_client_get_public_url(
     response.raise_for_status()
     assert (
         response.headers["content-disposition"]
-        == "attachment; filename=custom_name.svg; filename*=UTF-8''custom_name.svg;"
+        == "attachment; filename=custom_name.svg; filename*=UTF-8''custom_name.svg"
     )
     assert response.content == file.file_content
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove trailing `;` from tests, that was changed in the newest storage-api version. 

## Additional context

This got changed in between I commited https://github.com/supabase/storage-py/commit/c4a81fb9f7acacf8dccbf579daf4030200d8ab20 and when it was merged to master, causing it to break the CI tests. I believe it might be supabase cli version `2.34.2` (that bumped the storage-api version) that caused the change this.  
